### PR TITLE
Remove reverse; changed backend to order DESC

### DIFF
--- a/src/components/views/forum/Forum.tsx
+++ b/src/components/views/forum/Forum.tsx
@@ -108,7 +108,7 @@ export default function Forum({ user }: Props) {
         setThreadsGeneral(generalData);
         setThreadsCleaning(cleaningData);
         setThreadsTreatment(treatmentData);
-        setThreads(generalData.reverse());
+        setThreads(generalData);
       })
       .catch((error) => {
         console.error("Error fetching threads:", error);


### PR DESCRIPTION
# Remove reverse() on threads
- [ ] New feature
- [x] Bug fix 
- [ ] Hot Fix
- [ ] Chore
- [ ] Refactor
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Description
Changed backend to order by DESC automatically. The bug was even with the reverse the created_at time stamp wasn't being used so it was mixing old and new posts.
## Changes Made
- Forum.tsx line 111 - removed the .reverse() method from general data
- Add ORDER BY DESC for created_at in server file
