### PR TITLE
Chore/adjust mobile UI

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -57,7 +57,7 @@
     /* min-height: 18vh; */
     display: flex;
     /* flex-direction: row; */
-    align-items: flex-end;
+    align-items: center;
     justify-content: space-around;
     font-size: calc(10px + 1vmin);
     /* position: absolute; */

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -148,3 +148,17 @@
     display: none;
   }
 }
+
+@media screen and (max-width:899px){
+  .MuiGrid-root > .MuiGrid-item {
+    padding: 0px;
+    }
+    
+  .bottom {
+      order:2;
+  }
+
+  .top {
+      order:1;
+  }
+}

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -259,15 +259,15 @@ function App() {
         <Route path="/contact" element={<Contact/>}></Route>
         <Route path="/about" element={<About/>}></Route>
       </Routes>
-      <div id="footer_wrapper">
-        <div id="footer_container">
+      {/* <div id="footer_wrapper">
+        <div id="footer_container"> */}
           <footer className="App_footer">
             <p>Licensing info Syncfusion</p>
             <Link to="/contact"><p>Contact us</p></Link>
             <Link to="/about"><p>About</p></Link>
           </footer>
-        </div>
-      </div>
+        {/* </div>
+      </div> */}
     </div>
   );
 }

--- a/src/components/subComps/educationPageCard/EducationPageCard.tsx
+++ b/src/components/subComps/educationPageCard/EducationPageCard.tsx
@@ -8,6 +8,9 @@ import {
   Grid,
   Box,
   Stack,
+  createTheme,
+  responsiveFontSizes,
+  ThemeProvider
 } from "@mui/material";
 import {
   EducationCategory,
@@ -15,10 +18,13 @@ import {
 } from "../../../utils/interfaces";
 
 function EducationPageCard() {
+
+  let h3Theme = createTheme();
+  h3Theme = responsiveFontSizes(h3Theme);
+
   return (
-    <div className="outline-card">
-      <Box sx={{ height: "80vh" }}>
-        <Grid container spacing={5}>
+      <Box sx={{ height: "100vh" }}>
+        <Grid container spacing={5} height={"100vh"}>
           {educationCategories.map((educationCategory: EducationCategory) => {
             return (
               <Grid item key={educationCategory.type} xs={12} sm={6} md={4}>
@@ -64,11 +70,11 @@ function EducationPageCard() {
                             backgroundImage:
                               "linear-gradient(147deg, #fe8a39 0%, #fd3838 74%)",
                             borderRadius: 10,
-                            // 16
                             opacity: 0.5,
                           },
                         }}
                       >
+                        <ThemeProvider theme={h3Theme}>
                         <Typography
                           textAlign="center"
                           variant="h3"
@@ -76,6 +82,7 @@ function EducationPageCard() {
                         >
                           {educationCategory.category}
                         </Typography>
+                        </ThemeProvider>
                       </CardMedia>
                       <CardContent>
                         <Typography
@@ -95,7 +102,6 @@ function EducationPageCard() {
           })}
         </Grid>
       </Box>
-    </div>
   );
 }
 

--- a/src/components/subComps/outlineCard/OutlineCard.tsx
+++ b/src/components/subComps/outlineCard/OutlineCard.tsx
@@ -8,12 +8,15 @@ import {
   Box,
   Stack,
 } from "@mui/material";
+import { createTheme, ThemeProvider, responsiveFontSizes, } from '@mui/material/styles';
 import { motion } from "framer-motion";
 import { Service, services } from "../../../utils/interfaces";
 
 function OutlineCard() {
+  let theme = createTheme();
+  theme = responsiveFontSizes(theme);
+
   return (
-    <div className="outline-card">
       <Box sx={{ backgroundColor: "#ecedff4b", padding: 5 }}>
         <Typography
           variant="h3"
@@ -28,9 +31,6 @@ function OutlineCard() {
         <Grid
           container
           justifyContent="center"
-          alignItems="center"
-          spacing={5}
-          columns={3}
           paddingY={15}
         >
           {services.map((service: Service) => {
@@ -99,13 +99,16 @@ function OutlineCard() {
                           },
                         }}
                       >
+                        <ThemeProvider theme={theme}>
                         <Typography
                           textAlign="center"
                           variant="h2"
+                          fontWeight={500}
                           sx={{ mt: 5 }}
                         >
                           {service.name}
                         </Typography>
+                        </ThemeProvider>
                       </CardMedia>
                       <CardContent>
                         <Typography
@@ -125,7 +128,6 @@ function OutlineCard() {
           })}
         </Grid>
       </Box>
-    </div>
   );
 }
 

--- a/src/components/subComps/outlineCard/OutlineCard.tsx
+++ b/src/components/subComps/outlineCard/OutlineCard.tsx
@@ -7,8 +7,10 @@ import {
   Grid,
   Box,
   Stack,
+  createTheme,
+  ThemeProvider,
+  responsiveFontSizes,
 } from "@mui/material";
-import { createTheme, ThemeProvider, responsiveFontSizes, } from '@mui/material/styles';
 import { motion } from "framer-motion";
 import { Service, services } from "../../../utils/interfaces";
 

--- a/src/components/views/education/Education.tsx
+++ b/src/components/views/education/Education.tsx
@@ -5,7 +5,8 @@ function Education() {
   return (
     <Container
       sx={{
-        my: 14,
+        mt: 18,
+        mb: 100,
       }}
     >
       <EducationPageCard />

--- a/src/components/views/educationCategory/EducationCategory.tsx
+++ b/src/components/views/educationCategory/EducationCategory.tsx
@@ -67,19 +67,18 @@ const EducationCategory: React.FC<EducationCategoryProps> = ({
   };
 
   return (
-    <>
       <Container
         sx={{
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           mb: "30px",
+          height: "100vh",
         }}
       >
         <Typography sx={{ my: "20px" }} variant="h2">
           {getTitle(category)}
         </Typography>
-        <Box>
           <Grid
             container
             justifyContent="center"
@@ -89,9 +88,7 @@ const EducationCategory: React.FC<EducationCategoryProps> = ({
           >
             {articleCards}
           </Grid>
-        </Box>
       </Container>
-    </>
   );
 };
 

--- a/src/components/views/forum/Forum.tsx
+++ b/src/components/views/forum/Forum.tsx
@@ -26,6 +26,7 @@ import {
   InputLabel,
   Collapse,
   Alert,
+  Divider,
 } from "@mui/material";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import ChatOutlinedIcon from "@mui/icons-material/ChatOutlined";
@@ -405,13 +406,13 @@ export default function Forum({ user }: Props) {
           </Box>
         </Modal>
       </Container>
-      <Grid container spacing={2} sx={{ px: 6 }}>
-        <Grid item xs={12} sm={12} md={8} lg={8} xl={8} sx={{ mt: 4 }}>
-          <Card sx={{ mb: 2, height: 220, p: 2 }}>
+      <Grid container spacing={2} sx={{ px: "5%" }}>
+        <Grid item xs={12} sm={12} md={8} lg={8} xl={8} sx={{ mt: 4 }} className="bottom">
+          <Card sx={{ mb: 1, height: 220, p: 2, overflowY: "scroll" }}>
             <Typography sx={{ my: 2 }} variant="h4">
               Community Forum
             </Typography>
-            <Typography color="#636363">
+            <Typography color="#636363" >
               Use this forum to connect with other pet parents going through the
               same experience. Find answers to your questions about cleaning,
               treatment, or general information around ringworm. Please be
@@ -463,7 +464,7 @@ export default function Forum({ user }: Props) {
                   </Box>
                 </Box>
                 <CardActionArea
-                  sx={{ height: 120, overflow: "hidden" }}
+                  sx={{ height: 110, overflow: "hidden", mt: 1 }}
                   onClick={() =>
                     navigate(`/threads/${thread.category}/${thread.id}`)
                   }
@@ -477,6 +478,7 @@ export default function Forum({ user }: Props) {
                     dangerouslySetInnerHTML={createMarkup(thread.root_content)}
                   />
                 </CardActionArea>
+                <Divider></Divider>
                 <Box
                   display="flex"
                   flexDirection="row"
@@ -512,9 +514,9 @@ export default function Forum({ user }: Props) {
             </Card>
           ))}
         </Grid>
-        <Grid item xs={12} sm={12} md={4} lg={4} xl={4} sx={{ mt: 4 }}>
+        <Grid item xs={12} sm={12} md={4} lg={4} xl={4} sx={{ mt: 4 }} className="top">
           <Card
-            sx={{ width: "100%", mb: 5, p: 1 }}
+            sx={{ mb: 5, p: 1 }}
             onClick={() => setOpen(true)}
           >
             <CardActionArea sx={{ display: "flex", flexDirection: "row" }}>
@@ -525,7 +527,7 @@ export default function Forum({ user }: Props) {
             </CardActionArea>
           </Card>
           <Card
-            sx={{ width: "100%", mb: 5, p: 1 }}
+            sx={{ mb: 5, p: 1 }}
             onClick={() => navigate(`/threads/byme/${user.data.id}`)}
           >
             <CardActionArea
@@ -538,7 +540,7 @@ export default function Forum({ user }: Props) {
               <StarBorderIcon color="disabled"></StarBorderIcon>
             </CardActionArea>
           </Card>
-          <Card sx={{ width: "100%", mb: 5, p: 1 }}>
+          <Card sx={{ mb: 5, p: 1 }}>
             <CardActionArea
               sx={{ display: "flex", flexDirection: "row" }}
               disabled

--- a/src/components/views/mainDashboard/dashboardComponents/PetCards.tsx
+++ b/src/components/views/mainDashboard/dashboardComponents/PetCards.tsx
@@ -33,7 +33,7 @@ function PetCards({ user, setTargetPetFunc, pets }: Props) {
 
   return (
     <Grid container spacing={1} direction={"row"}>
-      <Grid item xs={12} sm={6} md={4} lg={3}>
+      <Grid item xs={12} sm={6} md={4} lg={3} ml={.5} mr={-.9}>
         {pets &&
           pets?.map((pet: any) => {
             return (
@@ -75,13 +75,13 @@ function PetCards({ user, setTargetPetFunc, pets }: Props) {
             );
           })}
       </Grid>
-      <Grid item xs={12} sm={6} md={4} lg={3} ml={1} mt={1}>
+      <Grid item xs={12} sm={6} md={4} lg={3} ml={1.7} mt={1.5}>
         <Link
           id="add-pet-link"
           className="dash-links"
           to={`/user/${user.data.id}/addpet`}
         >
-          <Card sx={style}>
+          <Card sx={style} >
             <CardHeader
               title="Add Pet"
               titleTypographyProps={{

--- a/src/components/views/managePets/AllPetsManagement.tsx
+++ b/src/components/views/managePets/AllPetsManagement.tsx
@@ -51,11 +51,11 @@ export default function AllPetsManagement({ user, pets, getUserPets }: Props) {
           </Button>
         </Stack>
       )}
-      <Stack sx={{ justifyContent: "center", mt: 5, mb: 50 }}>
+      <Stack direction="column" sx={{ mt: 5, height: "80vh" }}>
         <Grid
           container
           spacing={4}
-          columns={3}
+          // columns={3}
           sx={{ justifyContent: "center" }}
         >
           {petCard}

--- a/src/components/views/managePets/SinglePetChangeREFORMAT.tsx
+++ b/src/components/views/managePets/SinglePetChangeREFORMAT.tsx
@@ -17,6 +17,9 @@ import {
   Stack,
   Grid,
   Modal,
+  createTheme,
+  responsiveFontSizes,
+  ThemeProvider,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -40,6 +43,9 @@ import {
 interface Props {
   pet: any;
 }
+
+let theme = createTheme();
+theme = responsiveFontSizes(theme);
 
 const style = {
   position: "absolute" as "absolute",
@@ -206,7 +212,7 @@ export const SinglePetChange = ({ pet }: Props) => {
             We are hoping this means {pet.name} is ringworm-free!
           </Typography>
 
-          <Stack direction="row" sx={{ mt: 5 }}>
+          <Stack direction="row" sx={{ mt: 5, height: "100vh", width: "100%" }}>
             <Button variant="outlined" onClick={() => setIsOpen(false)}>
               Cancel
             </Button>
@@ -220,8 +226,8 @@ export const SinglePetChange = ({ pet }: Props) => {
           </Stack>
         </Box>
       </Modal>
-      <Grid item>
-        <Accordion sx={{ marginRight: 3 }}>
+      <Grid item lg={8} sm={8} xs={12}>
+        <Accordion>
           <AccordionSummary
             expandIcon={<ArrowDropDownIcon />}
             aria-controls={`${pet.name}-content`}
@@ -244,13 +250,13 @@ export const SinglePetChange = ({ pet }: Props) => {
                 }}
               >
                 <img src={paw} id="paw-svg" alt="Outline of a dog paw" />
-                <Typography sx={{ flexShrink: 0 }}>{pet.name}</Typography>
+                  <Typography >{pet.name}</Typography>
               </Box>
-              <Typography sx={{ color: "text.secondary" }}>
-                Edit pet information
-              </Typography>
+                <Typography  sx={{ color: "text.secondary", flexShrink: 0 }}>
+                  Click to edit
+                </Typography>
               <Button
-                sx={{ color: "#e00000" }}
+                sx={{ color: "#e00000", flexShrink: 2 }}
                 startIcon={<DeleteIcon />}
                 onClick={() => {
                   setIsOpen(true);
@@ -260,6 +266,7 @@ export const SinglePetChange = ({ pet }: Props) => {
               </Button>
             </Box>
           </AccordionSummary>
+
           <AccordionDetails>
             <Container maxWidth="sm">
               <Box

--- a/src/components/views/petDashboard/PetDashboard.tsx
+++ b/src/components/views/petDashboard/PetDashboard.tsx
@@ -58,10 +58,6 @@ export default function PetDashboard({ pet }: Props) {
             display: "flex",
             alignItems: "center",
             marginBottom: 2,
-            // backgroundColor: "#5E6697",
-            // backgroundImage:
-            //   "linear-gradient(147deg, #ECEDFF 0%, #B48BCC 20%, #ECEDFF 94%)",
-            // "&:after": { opacity: 0.5 },
           }}
         >
           <Typography variant="h1" sx={{ fontSize: "50px", color: "#4e547d" }}>


### PR DESCRIPTION
# Adjust for mobile UI
- [ ] New feature
- [ ] Bug fix 
- [ ] Hot Fix
- [x] Chore
- [x] Refactor
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Changes Made
- **Fix:** Pet management right margins were off center on mobile
- **Fix:** Outline cards on landing text was not responsive, all cards were off center
- **Fix:** Dashboard pet cards were slightly longer on the left
- **Fix:** Forum: order of the add thread buttons when position moved to stack on mobile; margins were way too extreme for mobile
- **Hot Fix:** The god ***** footer was floating in the middle of the education page AGAIN. Hot fix technically works it just doesn't fit with the rest of the site now (fix was adding a massive margin-bottom)
